### PR TITLE
fix: log an error when inbound fails

### DIFF
--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -117,6 +117,7 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Client<N, C> {
     async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
+            error!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' - {error}");
                 Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -113,6 +113,7 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
     async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
+            error!("Failed to process inbound message from '{peer_addr}' - {error}");
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' - {error}");
                 Outbound::send(self, peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));


### PR DESCRIPTION
Currently when `self.inbound()` fails, sometimes, nothing is logged, and you don't see that anything went wrong.

This tripped me up when diagnosing sync issues.